### PR TITLE
Improve logging and return history

### DIFF
--- a/run_centralized.py
+++ b/run_centralized.py
@@ -2,6 +2,9 @@
 """Simple centralized training runner."""
 import argparse
 from pathlib import Path
+import logging
+import sys
+
 from omegaconf import OmegaConf
 from train.centralized import run_centralized_training
 
@@ -9,11 +12,24 @@ from train.centralized import run_centralized_training
 def main() -> None:
     p = argparse.ArgumentParser(description="Centralized training")
     p.add_argument("--config", "-c", type=Path, required=True, help="YAML config")
+    p.add_argument("--verbose", "-v", action="store_true", help="상세 로그 출력")
+    p.add_argument("--log-file", type=Path, default=None, help="로그 저장 경로")
     args = p.parse_args()
+
+    handlers = [logging.StreamHandler(sys.stdout)]
+    if args.log_file:
+        handlers.append(logging.FileHandler(args.log_file))
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+        handlers=handlers,
+    )
+    log = logging.getLogger("run_centralized")
 
     if not args.config.exists():
         raise FileNotFoundError(args.config)
     cfg = OmegaConf.load(args.config)
+    log.info("Starting centralized training")
     run_centralized_training(cfg)
 
 

--- a/train/centralized.py
+++ b/train/centralized.py
@@ -1,6 +1,7 @@
 import csv
 from pathlib import Path
 from typing import Tuple
+import logging
 
 import torch
 from torch.utils.data import DataLoader
@@ -68,7 +69,9 @@ def run_centralized_training(cfg: DictConfig) -> None:
         val_loss, val_acc = _evaluate(model, test_loader, criterion)
         history["loss"].append(val_loss)
         history["acc"].append(val_acc)
-        print(f"Epoch {epoch+1}/{cfg.train.epochs} - loss: {val_loss:.4f} acc: {val_acc:.4f}")
+        logging.info(
+            f"Epoch {epoch+1}/{cfg.train.epochs} - loss: {val_loss:.4f} acc: {val_acc:.4f}"
+        )
 
     out_dir = Path(cfg.save.path)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -86,3 +89,4 @@ def run_centralized_training(cfg: DictConfig) -> None:
     plt.tight_layout()
     plt.savefig(out_dir / "history.png")
     plt.close()
+    logging.info(f"Results saved to {out_dir}")


### PR DESCRIPTION
## Summary
- add extensive logging to training scripts
- return `History` from federated training
- configure logging and options in run scripts

## Testing
- `python -m py_compile run_federated.py run_centralized.py train/federated.py train/centralized.py`

------
https://chatgpt.com/codex/tasks/task_e_68496cecf35083229963ac73d19666ed